### PR TITLE
Bump version to 0.1.8 and update emit method

### DIFF
--- a/snakemake_logger_plugin_flowo/__init__.py
+++ b/snakemake_logger_plugin_flowo/__init__.py
@@ -7,7 +7,7 @@ A logger plugin for Snakemake that stores workflow execution data in PostgreSQL.
 from snakemake_interface_logger_plugins.base import LogHandlerBase
 from .log_handler import PostgresqlLogHandler
 
-__version__ = "0.1.0"
+__version__ = "0.1.8"
 
 from .config import logger
 
@@ -15,6 +15,9 @@ from .config import logger
 class LogHandler(LogHandlerBase, PostgresqlLogHandler):
     """Main LogHandler class for the PostgreSQL plugin."""
 
+    def emit(self, record):
+        return PostgresqlLogHandler.emit(self, record)
+    
     def __post_init__(self) -> None:
         PostgresqlLogHandler.__init__(self, self.common_settings)
         if not self.db_connected():


### PR DESCRIPTION
- Bump version to match project version
- Fix abstract method resolution for `LogHandler.emit`. Explicitly define `emit() `in `LogHandler` to satisfy `LogHandlerBase`'s abstract requirement. Python's ABC mechanism doesn't recognize the inherited method from `PostgresqlLogHandler` due to MRO ordering. Fixes: `TypeErro`r when instantiating `LogHandler`. Alternatively, you may also just need to reorder `LogHandler(LogHandlerBase, PostgresqlLogHandler)` parent classes but I haven't tested it.

Explicit error:
```
$ snakemake -c16 --rerun-incomplete --logger flowo --config flowo_project_name="hello flowo"                                                                             
Traceback (most recent call last):                                                                                                                                                                               
                                                                                                                                                                                                                 
  File "/home/vlad/code/all_flu/.pixi/envs/default/lib/python3.13/site-packages/snakemake/cli.py", line 2277, in main                                                                                            
    success = args_to_api(args, parser)                                                                 
                                                                                                        
  File "/home/vlad/code/all_flu/.pixi/envs/default/lib/python3.13/site-packages/snakemake/cli.py", line 2010, in args_to_api                                                                                     
    with SnakemakeApi(output_settings) as snakemake_api:                                                
         ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^              

  File "<string>", line 4, in __init__              

  File "/home/vlad/code/all_flu/.pixi/envs/default/lib/python3.13/site-packages/snakemake/api.py", line 112, in __post_init__                                                                                    
    self.setup_logger()                             
    ~~~~~~~~~~~~~~~~~^^                             

  File "/home/vlad/code/all_flu/.pixi/envs/default/lib/python3.13/site-packages/snakemake/api.py", line 263, in setup_logger                                                                                     
    log_handlers.append(plugin.log_handler(self.output_settings, settings))                             
                        ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                              

TypeError: Can't instantiate abstract class LogHandler without an implementation for abstract method 'emit' `
```

I tested this locally with the modified code.